### PR TITLE
Mono debugger

### DIFF
--- a/Bonsai.LinuxEnvironmentTemplate/.template.config/template.json
+++ b/Bonsai.LinuxEnvironmentTemplate/.template.config/template.json
@@ -20,8 +20,8 @@
         "include-vscode-debugger-config": {
             "type": "parameter",
             "datatype": "bool",
-            "defaultValue": "true",
-            "description": "Include debugger configuration files"
+            "defaultValue": "false",
+            "description": "Include vscode debugger configuration files"
         }
     },
     "postActions": [{

--- a/Bonsai.LinuxEnvironmentTemplate/vscode/launch.json.template
+++ b/Bonsai.LinuxEnvironmentTemplate/vscode/launch.json.template
@@ -2,24 +2,21 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        },
-        {
-            "name": "Launch Bonsai",
+            "name": "Debug Bonsai",
             "type": "coreclr",
             "request": "launch",
-            "program": "/usr/bin/bash",
+            "program": "${workspaceFolder}/.bonsai/Bonsai.exe",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Debug Mono Bonsai",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceFolder}/.bonsai/Bonsai.exe",
             "cwd": "${workspaceFolder}",
-            "args": [
-                "${workspaceFolder}/.bonsai/run"
-            ],
             "env": {
-                "BONSAI_EXE_PATH": "${workspaceFolder}/.bonsai/Bonsai.exe",
                 "GTK_DATA_PREFIX": "None"
             }
         }
-
     ]
 }


### PR DESCRIPTION
# Summary

This PR modifies the behavior of the template to not include the vscode debugger by default. It also changes the debugger config to use the mono debugger and adds a windows debugger